### PR TITLE
Switch to GeistSans font and add geist package

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
-import { JetBrains_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { Navbar } from "@/components/layout/navbar";
 import { ThemeProvider } from "@/components/layout/theme-provider";
-const inter = JetBrains_Mono({ subsets: ["latin"] });
+const inter = GeistSans;
 
 export const metadata: Metadata = {
     title: "DevSphere",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.1.3",
+        "geist": "^1.4.2",
         "lucide-react": "^0.383.0",
         "next": "14.2.3",
         "next-themes": "^0.3.0",
@@ -4185,6 +4186,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.4.2.tgz",
+      "integrity": "sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.1.3",
+    "geist": "^1.4.2",
     "lucide-react": "^0.383.0",
     "next": "14.2.3",
     "next-themes": "^0.3.0",


### PR DESCRIPTION
Replaced JetBrains_Mono with GeistSans in layout.tsx for updated typography. Added the 'geist' package to dependencies in package.json.